### PR TITLE
Make journal volume numbers bold

### DIFF
--- a/lncs.bbx
+++ b/lncs.bbx
@@ -9,7 +9,7 @@
 
 \newtoggle{lncs:abbrev}
 \newtoggle{lncs:series}
-\newtoggle{lncs:conference}  
+\newtoggle{lncs:conference}
 \newtoggle{lncs:lncs}
 \DeclareBibliographyOption{acronym}[true]{\toggletrue{lncs:abbrev}}
 \DeclareBibliographyOption{series}[no]{
@@ -22,7 +22,7 @@
   \ifstrequal{#1}{full}{}{}
   \ifstrequal{#1}{acronym}{}{}
 }
-  
+
 \DeclareFieldFormat{labelnumberwidth}{#1.}
 \defbibenvironment{bibliography}
   {\list
@@ -57,6 +57,7 @@
 \DeclareFieldFormat{journaltitle}{#1}
 \DeclareFieldFormat[article,book,inproceedings,incollection, online,report,thesis]{title}{#1}
 \DeclareFieldFormat{booktitle}{#1}
+\DeclareFieldFormat[article]{volume}{\textbf{#1}}
 \DeclareFieldFormat[article]{pages}{#1}
 \DeclareFieldFormat{year}{(#1)}
 \DeclareFieldFormat{acronym}{#1}

--- a/test.tex
+++ b/test.tex
@@ -15,7 +15,7 @@ manual:
 \bibitem{jour}
 Smith, T.F., Waterman, M.S.:
 Identification of Common Molecular Subsequences.
-J. Mol. Biol. 147, 195--197 (1981)
+J. Mol. Biol. \textbf{147}, 195--197 (1981)
 
 \bibitem{lncschap}
 May, P., Ehrlich, H.-C., Steinke, T.:
@@ -48,17 +48,17 @@ National Center for Biotechnology Information,
 \bibitem{clar:eke}
 Clarke, F., Ekeland, I.:
 Nonlinear oscillations and boundary-value problems for Hamiltonian systems.
-Arch. Rat. Mech. Anal. 78, 315--333 (1982)
+Arch. Rat. Mech. Anal. \textbf{78}, 315--333 (1982)
 
 \bibitem{clar:eke:2}
 Clarke, F., Ekeland, I.:
 Solutions p\'{e}riodiques, du p\'{e}riode donn\'{e}e, des \'{e}quations hamiltoniennes.
-Note CRAS Paris 287, 1013--1015 (1978)
+Note CRAS Paris \textbf{287}, 1013--1015 (1978)
 
 \bibitem{mich:tar}
 Michalek, R., Tarantello, G.:
 Subharmonic solutions with prescribed minimal period for nonautonomous Hamiltonian systems.
-J. Diff. Eq. 72, 28--55 (1988)
+J. Diff. Eq. \textbf{72}, 28--55 (1988)
 
 \bibitem{tar}
 Tarantello, G.:
@@ -68,7 +68,7 @@ Annali di Matematica Pura (to appear)
 \bibitem{rab}
 Rabinowitz, P.:
 On subharmonic solutions of a Hamiltonian system.
-Comm. Pure Appl. Math. 33, 609--633 (1980)
+Comm. Pure Appl. Math. \textbf{33}, 609--633 (1980)
 \end{thebibliography}
 
 \end{document}


### PR DESCRIPTION
From what I can tell, volume numbers for journals (not proceedings) should be bold in LNCS style. This is an attempt to fix that.